### PR TITLE
[IE-40] Building examples with sbt < 0.13.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,18 +1,27 @@
 name := "insightedge-examples"
+
 version := "0.3.0"
+
 scalaVersion := "2.10.6"
 
-resolvers += Resolver.mavenLocal
-libraryDependencies += "com.gigaspaces.insightedge" % "insightedge-core" % "0.3.0" % "provided"
-libraryDependencies += "com.gigaspaces.insightedge" % "gigaspaces-scala" % "0.3.0" % "provided"
+val insightEdgeVersion = "0.3.0"
 
-libraryDependencies += "org.apache.spark" % "spark-streaming-twitter_2.10" % "1.6.0"
-libraryDependencies += "org.scalatest" % "scalatest_2.10" % "2.0" % "test"
+resolvers += Resolver.mavenLocal
+
+libraryDependencies ++= Seq(
+  "com.gigaspaces.insightedge" % "insightedge-core" % insightEdgeVersion % "provided",
+  "com.gigaspaces.insightedge" % "gigaspaces-scala" % insightEdgeVersion % "provided",
+  "org.apache.spark" %% "spark-streaming-twitter" % "1.6.0",
+  "org.scalatest" %% "scalatest" % "2.0" % "test"
+)
 
 test in assembly := {}
+
 assemblyOutputPath in assembly := new File("target/insightedge-examples.jar")
+
 assemblyMergeStrategy in assembly := {
   case PathList("org", "apache", "spark", "unused", "UnusedStubClass.class") => MergeStrategy.first
   case x => (assemblyMergeStrategy in assembly).value(x)
 }
+
 assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)


### PR DESCRIPTION
- fixed building with sbt < 0.13.7
- extracted insighedge version to val
- used %% for "spark-streaming-twitter" and "scalatest"
