### PR TITLE
[IE-12] Simplify examples by defaulting to unicast

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ For example, `SaveRDD` can be submitted with the next syntax:
     spark://127.0.0.1:7077 insightedge-space insightedge 127.0.0.1:4174
 ```
 
+You can omit arguments for the examples to use local cluster with default settings (mentioned above):
+```bash
+./bin/insightedge-submit --class {main class name} --master {Spark master URL} {insightedge-examples.jar location}
+```
+
 > Note that running `TwitterPopularTags` example requires you to pass [Twitter app tokens](https://apps.twitter.com/) as arguments
 
 #### Stopping local environment

--- a/README.md
+++ b/README.md
@@ -80,9 +80,10 @@ For example, `SaveRDD` can be submitted with the next syntax:
     spark://127.0.0.1:7077 insightedge-space insightedge 127.0.0.1:4174
 ```
 
-You can omit arguments for the examples to use local cluster with default settings (mentioned above):
+If you are running local cluster with default settings (see [Running Examples](#running-examples)), you can omit arguments:
 ```bash
-./bin/insightedge-submit --class {main class name} --master {Spark master URL} {insightedge-examples.jar location}
+./bin/insightedge-submit --class {main class name} --master {Spark master URL} \
+    {insightedge-examples.jar location}
 ```
 
 > Note that running `TwitterPopularTags` example requires you to pass [Twitter app tokens](https://apps.twitter.com/) as arguments

--- a/src/main/scala/com/gigaspaces/insightedge/examples/basic/LoadDataFrame.scala
+++ b/src/main/scala/com/gigaspaces/insightedge/examples/basic/LoadDataFrame.scala
@@ -10,11 +10,12 @@ import org.apache.spark.{SparkConf, SparkContext}
 object LoadDataFrame {
 
   def main(args: Array[String]): Unit = {
-    if (args.length < 4) {
+    val settings = if (args.length > 0) args else Array("spark://127.0.0.1:7077", "insightedge-space", "insightedge", "127.0.0.1:4174")
+    if (settings.length < 4) {
       System.err.println("Usage: LoadDataFrame <spark master url> <space name> <space groups> <space locator>")
       System.exit(1)
     }
-    val Array(master, space, groups, locators) = args
+    val Array(master, space, groups, locators) = settings
     val gsConfig = GigaSpacesConfig(space, Some(groups), Some(locators))
     val sc = new SparkContext(new SparkConf().setAppName("example-load-dataframe").setMaster(master).setGigaSpaceConfig(gsConfig))
 

--- a/src/main/scala/com/gigaspaces/insightedge/examples/basic/LoadRdd.scala
+++ b/src/main/scala/com/gigaspaces/insightedge/examples/basic/LoadRdd.scala
@@ -10,11 +10,12 @@ import org.apache.spark.{SparkConf, SparkContext}
 object LoadRdd {
 
   def main(args: Array[String]): Unit = {
-    if (args.length < 4) {
+    val settings = if (args.length > 0) args else Array("spark://127.0.0.1:7077", "insightedge-space", "insightedge", "127.0.0.1:4174")
+    if (settings.length < 4) {
       System.err.println("Usage: LoadRdd <spark master url> <space name> <space groups> <space locator>")
       System.exit(1)
     }
-    val Array(master, space, groups, locators) = args
+    val Array(master, space, groups, locators) = settings
     val gsConfig = GigaSpacesConfig(space, Some(groups), Some(locators))
     val sc = new SparkContext(new SparkConf().setAppName("example-load-rdd").setMaster(master).setGigaSpaceConfig(gsConfig))
 

--- a/src/main/scala/com/gigaspaces/insightedge/examples/basic/LoadRddWithSql.scala
+++ b/src/main/scala/com/gigaspaces/insightedge/examples/basic/LoadRddWithSql.scala
@@ -10,11 +10,12 @@ import org.apache.spark.{SparkConf, SparkContext}
 object LoadRddWithSql {
 
   def main(args: Array[String]): Unit = {
-    if (args.length < 4) {
+    val settings = if (args.length > 0) args else Array("spark://127.0.0.1:7077", "insightedge-space", "insightedge", "127.0.0.1:4174")
+    if (settings.length < 4) {
       System.err.println("Usage: LoadRddWithSql <spark master url> <space name> <space groups> <space locator>")
       System.exit(1)
     }
-    val Array(master, space, groups, locators) = args
+    val Array(master, space, groups, locators) = settings
     val gsConfig = GigaSpacesConfig(space, Some(groups), Some(locators))
     val sc = new SparkContext(new SparkConf().setAppName("example-load-rdd-sql").setMaster(master).setGigaSpaceConfig(gsConfig))
 

--- a/src/main/scala/com/gigaspaces/insightedge/examples/basic/PersistDataFrame.scala
+++ b/src/main/scala/com/gigaspaces/insightedge/examples/basic/PersistDataFrame.scala
@@ -12,11 +12,12 @@ import org.apache.spark.{SparkConf, SparkContext}
 object PersistDataFrame {
 
   def main(args: Array[String]): Unit = {
-    if (args.length < 4) {
+    val settings = if (args.length > 0) args else Array("spark://127.0.0.1:7077", "insightedge-space", "insightedge", "127.0.0.1:4174")
+    if (settings.length < 4) {
       System.err.println("Usage: PersistDataFrame <spark master url> <space name> <space groups> <space locator>")
       System.exit(1)
     }
-    val Array(master, space, groups, locators) = args
+    val Array(master, space, groups, locators) = settings
     val gsConfig = GigaSpacesConfig(space, Some(groups), Some(locators))
     val sc = new SparkContext(new SparkConf().setAppName("example-persist-dataframe").setMaster(master).setGigaSpaceConfig(gsConfig))
     val sqlContext = new SQLContext(sc)

--- a/src/main/scala/com/gigaspaces/insightedge/examples/basic/SaveRdd.scala
+++ b/src/main/scala/com/gigaspaces/insightedge/examples/basic/SaveRdd.scala
@@ -13,11 +13,12 @@ import scala.util.Random
 object SaveRdd {
 
   def main(args: Array[String]): Unit = {
-    if (args.length < 4) {
+    val settings = if (args.length > 0) args else Array("spark://127.0.0.1:7077", "insightedge-space", "insightedge", "127.0.0.1:4174")
+    if (settings.length < 4) {
       System.err.println("Usage: SaveRdd <spark master url> <space name> <space groups> <space locator>")
       System.exit(1)
     }
-    val Array(master, space, groups, locators) = args
+    val Array(master, space, groups, locators) = settings
     val gsConfig = GigaSpacesConfig(space, Some(groups), Some(locators))
     val sc = new SparkContext(new SparkConf().setAppName("example-save-rdd").setMaster(master).setGigaSpaceConfig(gsConfig))
 

--- a/src/main/scala/com/gigaspaces/insightedge/examples/mllib/SaveAndLoadMLModel.scala
+++ b/src/main/scala/com/gigaspaces/insightedge/examples/mllib/SaveAndLoadMLModel.scala
@@ -13,11 +13,12 @@ import org.apache.spark.{SparkConf, SparkContext}
 object SaveAndLoadMLModel {
 
   def main(args: Array[String]): Unit = {
-    if (args.length < 4) {
+    val settings = if (args.length > 0) args else Array("spark://127.0.0.1:7077", "insightedge-space", "insightedge", "127.0.0.1:4174")
+    if (settings.length < 4) {
       System.err.println("Usage: SaveAndLoadMLModel <spark master url> <space name> <space groups> <space locator>")
       System.exit(1)
     }
-    val Array(master, space, groups, locators) = args
+    val Array(master, space, groups, locators) = settings
     val gsConfig = GigaSpacesConfig(space, Some(groups), Some(locators))
     val sc = new SparkContext(new SparkConf().setAppName("example-mllib").setMaster(master).setGigaSpaceConfig(gsConfig))
 

--- a/src/main/scala/com/gigaspaces/insightedge/examples/offheap/OffHeapPersistence.scala
+++ b/src/main/scala/com/gigaspaces/insightedge/examples/offheap/OffHeapPersistence.scala
@@ -14,11 +14,12 @@ import scala.util.Random
 object OffHeapPersistence {
 
   def main(args: Array[String]): Unit = {
-    if (args.length < 4) {
+    val settings = if (args.length > 0) args else Array("spark://127.0.0.1:7077", "insightedge-space", "insightedge", "127.0.0.1:4174")
+    if (settings.length < 4) {
       System.err.println("Usage: OffHeapPersistence <spark master url> <space name> <space groups> <space locator>")
       System.exit(1)
     }
-    val Array(master, space, groups, locators) = args
+    val Array(master, space, groups, locators) = settings
     val gsConfig = GigaSpacesConfig(space, Some(groups), Some(locators))
     val sparkConfig = new SparkConf()
       .setAppName("example-offheap")


### PR DESCRIPTION
Instead of omitting space group, users will be able to omit full configuration if they run "demo" mode as suggested in the readme.
