### PR TITLE
[IE-91] fixing build warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
+                <version>2.4.3</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
fixed only the first warning from the ticket. 
The second one is not obvious, will ignore for now.
