### PR TITLE
[IE-110] Remove shortcut to dataframes from GigaspacesSparkContext

### DIFF
--- a/src/main/scala/com/gigaspaces/insightedge/examples/basic/LoadDataFrame.scala
+++ b/src/main/scala/com/gigaspaces/insightedge/examples/basic/LoadDataFrame.scala
@@ -2,7 +2,9 @@ package com.gigaspaces.insightedge.examples.basic
 
 import com.gigaspaces.spark.context.GigaSpacesConfig
 import com.gigaspaces.spark.implicits._
+import org.apache.spark.sql.SQLContext
 import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.insightedge._
 
 /**
   * Loads Products from Data Grid as DataFrame and runs filtering.
@@ -19,7 +21,8 @@ object LoadDataFrame {
     val gsConfig = GigaSpacesConfig(space, Some(groups), Some(locators))
     val sc = new SparkContext(new SparkConf().setAppName("example-load-dataframe").setMaster(master).setGigaSpaceConfig(gsConfig))
 
-    val df = sc.gridDataFrame[Product]()
+    val sqlContext = new SQLContext(sc)
+    val df = sqlContext.read.grid.loadClass[Product]
     df.printSchema()
     val count = df.filter(df("quantity") < 5).count()
     println(s"Number of products with quantity < 5: $count")


### PR DESCRIPTION
[YouTrack](http://10.8.1.184:8080/issue/IE-110)
Updated documentation [here](https://github.com/InsightEdge/insightedge-docs/tree/dataframe-api)
